### PR TITLE
Fix shader &[u8] to Vec<u32> conversion

### DIFF
--- a/src/integration.rs
+++ b/src/integration.rs
@@ -29,8 +29,10 @@ pub struct Integration<A: Allocator + 'static> {
 
 impl<A: Allocator + 'static> Integration<A> {
     fn bytes_to_spirv(buffer: &[u8]) -> Vec<u32> {
-        let (_, binary, _) = unsafe { buffer.align_to::<u32>() };
-        Vec::from(binary)
+        buffer
+            .chunks_exact(4)
+            .map(|x| u32::from_le_bytes(x.try_into().unwrap()))
+            .collect()
     }
 
     pub fn new<T>(


### PR DESCRIPTION
Honestly do not know how align_to works because documentation says "Regular code running in a default (debug or release) execution will return a maximal middle part." but I do not know what "regular code" refers to because it did not return a maximal middle part in my case. Maybe memory shenanigans? Anyway here's a working (and also safe) version of that.